### PR TITLE
Space workaround furigana repeat chars

### DIFF
--- a/src/helper/JapaneseText.js
+++ b/src/helper/JapaneseText.js
@@ -122,7 +122,9 @@ export function furiganaParse(pronunciation, orthography) {
       //hiragana
       if (prevWasKanji) {
         while (pronunciation.charAt(start) != thisChar) {
-          fword += pronunciation.charAt(start);
+          if (pronunciation.charAt(start) !== " ") {
+            fword += pronunciation.charAt(start);
+          }
           start++;
 
           if (start > pronunciation.length) {
@@ -131,8 +133,8 @@ export function furiganaParse(pronunciation, orthography) {
         }
         furiganas.push(fword);
         fword = "";
-        nword += thisChar;
-      } else {
+      }
+      if (thisChar !== " ") {
         nword += thisChar;
       }
 
@@ -145,8 +147,12 @@ export function furiganaParse(pronunciation, orthography) {
       prevWasKanji = false;
     } else {
       // kanji
-      fword += pronunciation.charAt(start);
-      kword += thisChar;
+      if (pronunciation.charAt(start) !== " ") {
+        fword += pronunciation.charAt(start);
+      }
+      if (thisChar !== " ") {
+        kword += thisChar;
+      }
       prevWasKanji = true;
       start++;
       if (nword !== "") {
@@ -156,7 +162,9 @@ export function furiganaParse(pronunciation, orthography) {
 
       if (orthography.length - i === 1) {
         // (this) last character is a kanji
-        fword += pronunciation.substr(start);
+        if (pronunciation.substr(start) !== " ") {
+          fword += pronunciation.substr(start);
+        }
         furiganas.push(fword);
         kanjis.push(kword);
       }
@@ -173,9 +181,13 @@ export function furiganaParse(pronunciation, orthography) {
     startsWHiragana
   );
 
+  // remove spaces which are used as a workaround for parsing failure due to repeated chars
+  const pronunciationNoSpace = pronunciation.split(" ").join("");
+  const ortographyNoSpace = orthography.split(" ").join("");
+
   if (
-    pronunciationOutput !== pronunciation ||
-    orthographyOutput !== orthography
+    pronunciationOutput !== pronunciationNoSpace ||
+    orthographyOutput !== ortographyNoSpace
   ) {
     const err = new Error("Failed to parse text to build furigana");
     err.data = {

--- a/src/helper/JapaneseText.js
+++ b/src/helper/JapaneseText.js
@@ -1,5 +1,5 @@
 import React from "react";
-import { isHiragana } from "./hiraganaHelper";
+import { isHiragana, isKatakana } from "./hiraganaHelper";
 
 export class JapaneseText {
   constructor(furigana, kanji) {
@@ -74,7 +74,7 @@ export class JapaneseText {
       htmlElement = <div>{this._furigana}</div>;
     } else {
       try {
-        const { kanjis, furiganas, nonKanjis, startsWHiragana } = furiganaParse(
+        const { kanjis, furiganas, nonKanjis, startsWKana } = furiganaParse(
           this._furigana,
           this._kanji
         );
@@ -82,7 +82,7 @@ export class JapaneseText {
           kanjis,
           furiganas,
           nonKanjis,
-          startsWHiragana
+          startsWKana
         );
       } catch (e) {
         console.error(e);
@@ -100,13 +100,14 @@ export class JapaneseText {
 }
 
 /**
- * @returns  {{ kanjis:String[], furiganas:String[], nonKanjis:String[], startsWHiragana:boolean }} object containing parse info
+ * @returns  {{ kanjis:String[], furiganas:String[], nonKanjis:String[], startsWKana:boolean }} object containing parse info
  * @throws if the two phrases do not match or if the parsed output is invalid.
  * @param {String} pronunciation (hiragana)
  * @param {String} orthography (kanji)
  */
 export function furiganaParse(pronunciation, orthography) {
-  const startsWHiragana = isHiragana(orthography.charAt(0));
+  const startsWKana =
+    isHiragana(orthography.charAt(0)) || isKatakana(orthography.charAt(0));
 
   let start = 0;
   let furiganas = [];
@@ -118,8 +119,8 @@ export function furiganaParse(pronunciation, orthography) {
   let prevWasKanji = false;
 
   orthography.split("").forEach((thisChar, i) => {
-    if (isHiragana(thisChar)) {
-      //hiragana
+    if (isHiragana(thisChar) || isKatakana(thisChar)) {
+      //kana
       if (prevWasKanji) {
         while (pronunciation.charAt(start) != thisChar) {
           if (pronunciation.charAt(start) !== " ") {
@@ -178,7 +179,7 @@ export function furiganaParse(pronunciation, orthography) {
     kanjis,
     furiganas,
     nonKanjis,
-    startsWHiragana
+    startsWKana
   );
 
   // remove spaces which are used as a workaround for parsing failure due to repeated chars
@@ -200,7 +201,7 @@ export function furiganaParse(pronunciation, orthography) {
     throw err;
   }
 
-  return { kanjis, furiganas, nonKanjis, startsWHiragana };
+  return { kanjis, furiganas, nonKanjis, startsWKana };
 }
 
 /**
@@ -208,17 +209,17 @@ export function furiganaParse(pronunciation, orthography) {
  * @param {String[]} kanjis
  * @param {String[]} furiganas
  * @param {String[]} nonKanjis
- * @param {boolean} startsWHiragana
+ * @param {boolean} startsWKana
  */
 export function validateParseFurigana(
   kanjis,
   furiganas,
   nonKanjis,
-  startsWHiragana
+  startsWKana
 ) {
   let pronunciation, orthography;
 
-  if (startsWHiragana) {
+  if (startsWKana) {
     orthography = nonKanjis.reduce((a, n, i) => a + n + (kanjis[i] || ""), "");
     pronunciation = nonKanjis.reduce(
       (a, n, i) => a + n + (furiganas[i] || ""),
@@ -240,14 +241,9 @@ export function validateParseFurigana(
  * @param {String[]} kanjis
  * @param {String[]} furiganas
  * @param {String[]} nonKanjis
- * @param {boolean} startsWHiragana
+ * @param {boolean} startsWKana
  */
-export function buildHTMLElement(
-  kanjis,
-  furiganas,
-  nonKanjis,
-  startsWHiragana
-) {
+export function buildHTMLElement(kanjis, furiganas, nonKanjis, startsWKana) {
   let sentence = [];
   const kanjiWFurigana = kanjis.map((kanji, i) => (
     <ruby key={i}>
@@ -263,7 +259,7 @@ export function buildHTMLElement(
       : kanjiWFurigana.length;
 
   while (i < items) {
-    if (startsWHiragana) {
+    if (startsWKana) {
       //starts with hiragana
       sentence.push(
         <span key={i}>
@@ -303,7 +299,7 @@ export function htmlElementHint(japaneseText) {
       hint = undefined;
     } else {
       try {
-        const { kanjis, furiganas, nonKanjis, startsWHiragana } = furiganaParse(
+        const { kanjis, furiganas, nonKanjis, startsWKana } = furiganaParse(
           pronunciation,
           orthography
         );
@@ -313,7 +309,7 @@ export function htmlElementHint(japaneseText) {
         const firstnonKanji =
           nonKanjis.length > 0 ? nonKanjis[0][0] : undefined;
 
-        if (startsWHiragana) {
+        if (startsWKana) {
           //starts with hiragana
           hint = <span>{firstnonKanji}</span>;
         } else {
@@ -345,7 +341,7 @@ export function htmlElementHint(japaneseText) {
 /**
  * when word has override pronounce attr it is used otherwise the spelling is used
  * @returns {String} hiragana pronunciation
- * @param {*} vocabulary data object
+ * @param {{japanese: String, pronounce: String|undefined}} vocabulary data object
  */
 export function audioPronunciation(vocabulary) {
   let q;
@@ -360,7 +356,9 @@ export function audioPronunciation(vocabulary) {
     }
   } else {
     const w = JapaneseText.parse(vocabulary.japanese);
-    q = w.getSpelling();
+    const spelling = w.getSpelling();
+    // remove workaround-spaces
+    q = spelling.split(" ").join("");
   }
   return q;
 }

--- a/test/unit/helper/JapaneseText.js
+++ b/test/unit/helper/JapaneseText.js
@@ -68,7 +68,7 @@ describe("JapanseText", function () {
       const kanjis = ["会計", "願"];
       const furiganas = ["かいけい", "ねが"];
       const nonKanjis = ["お", "をお", "いします"];
-      const startsWHiragana = true;
+      const startsWKana = true;
 
       const expected = "お会計かいけいをお願ねがいします";
 
@@ -76,7 +76,7 @@ describe("JapanseText", function () {
         kanjis,
         furiganas,
         nonKanjis,
-        startsWHiragana
+        startsWKana
       );
       const wrapper = shallow(actual);
 
@@ -112,7 +112,7 @@ describe("JapanseText", function () {
       const furigana = "いつ つ"
       const kanji = "五 つ";
 
-      const { kanjis, furiganas, nonKanjis, startsWHiragana } = furiganaParse(
+      const { kanjis, furiganas, nonKanjis, startsWKana } = furiganaParse(
         furigana,
         kanji
       );
@@ -120,7 +120,7 @@ describe("JapanseText", function () {
       expect(kanjis, "kanjis").to.deep.eq(expectedKanjis);
       expect(furiganas, "furiganas").to.deep.eq(expectedFuriganas);
       expect(nonKanjis, "nonkanjis").to.deep.eq(expectedNonKanjis);
-      expect(startsWHiragana, "startsWHiragana").to.deep.eq(
+      expect(startsWKana, "startsWKana").to.deep.eq(
         expectedStartsWHiragana
       );
     });
@@ -133,7 +133,7 @@ describe("JapanseText", function () {
 
       const furigana = "きたない";
       const kanji = "汚い";
-      const { kanjis, furiganas, nonKanjis, startsWHiragana } = furiganaParse(
+      const { kanjis, furiganas, nonKanjis, startsWKana } = furiganaParse(
         furigana,
         kanji
       );
@@ -141,7 +141,7 @@ describe("JapanseText", function () {
       expect(kanjis, "kanjis").to.deep.eq(expectedKanjis);
       expect(furiganas, "furiganas").to.deep.eq(expectedFuriganas);
       expect(nonKanjis, "nonkanjis").to.deep.eq(expectedNonKanjis);
-      expect(startsWHiragana, "startsWHiragana").to.deep.eq(
+      expect(startsWKana, "startsWKana").to.deep.eq(
         expectedStartsWHiragana
       );
     });
@@ -155,7 +155,7 @@ describe("JapanseText", function () {
 
       const furigana = "はやおきはさんもんのとく";
       const kanji = "早起きは三文の得";
-      const { kanjis, furiganas, nonKanjis, startsWHiragana } = furiganaParse(
+      const { kanjis, furiganas, nonKanjis, startsWKana } = furiganaParse(
         furigana,
         kanji
       );
@@ -163,7 +163,7 @@ describe("JapanseText", function () {
       expect(kanjis, "kanjis").to.deep.eq(expectedKanjis);
       expect(furiganas, "furiganas").to.deep.eq(expectedFuriganas);
       expect(nonKanjis, "nonkanjis").to.deep.eq(expectedNonKanjis);
-      expect(startsWHiragana, "startsWHiragana").to.deep.eq(
+      expect(startsWKana, "startsWKana").to.deep.eq(
         expectedStartsWHiragana
       );
     });
@@ -176,7 +176,7 @@ describe("JapanseText", function () {
 
       const furigana = "ほおき";
       const kanji = "上記";
-      const { kanjis, furiganas, nonKanjis, startsWHiragana } = furiganaParse(
+      const { kanjis, furiganas, nonKanjis, startsWKana } = furiganaParse(
         furigana,
         kanji
       );
@@ -184,7 +184,7 @@ describe("JapanseText", function () {
       expect(kanjis, "kanjis").to.deep.eq(expectedKanjis);
       expect(furiganas, "furiganas").to.deep.eq(expectedFuriganas);
       expect(nonKanjis, "nonkanjis").to.deep.eq(expectedNonKanjis);
-      expect(startsWHiragana, "startsWHiragana").to.deep.eq(
+      expect(startsWKana, "startsWKana").to.deep.eq(
         expectedStartsWHiragana
       );
     });
@@ -197,7 +197,7 @@ describe("JapanseText", function () {
 
       const furigana = "こおり";
       const kanji = "氷";
-      const { kanjis, furiganas, nonKanjis, startsWHiragana } = furiganaParse(
+      const { kanjis, furiganas, nonKanjis, startsWKana } = furiganaParse(
         furigana,
         kanji
       );
@@ -205,7 +205,7 @@ describe("JapanseText", function () {
       expect(kanjis, "kanjis").to.deep.eq(expectedKanjis);
       expect(furiganas, "furiganas").to.deep.eq(expectedFuriganas);
       expect(nonKanjis, "nonkanjis").to.deep.eq(expectedNonKanjis);
-      expect(startsWHiragana, "startsWHiragana").to.deep.eq(
+      expect(startsWKana, "startsWKana").to.deep.eq(
         expectedStartsWHiragana
       );
     });
@@ -217,7 +217,7 @@ describe("JapanseText", function () {
 
       const furigana = "おかいけいをおねがいします。";
       const kanji = "お会計をお願いします。";
-      const { kanjis, furiganas, nonKanjis, startsWHiragana } = furiganaParse(
+      const { kanjis, furiganas, nonKanjis, startsWKana } = furiganaParse(
         furigana,
         kanji
       );
@@ -225,8 +225,27 @@ describe("JapanseText", function () {
       expect(kanjis).to.deep.eq(expectedKanjis);
       expect(furiganas).to.deep.eq(expectedFuriganas);
       expect(nonKanjis).to.deep.eq(expectedNonKanjis);
-      expect(startsWHiragana).to.deep.eq(expectedStartsWHiragana);
+      expect(startsWKana).to.deep.eq(expectedStartsWHiragana);
     });
+    it("starting with kanji contains hiragana and katakana", function () {
+      const expectedKanjis = ["消"];
+      const expectedFuriganas = ["け"];
+      const expectedNonKanjis = ["しゴム"];
+      const expectedStartsWHiragana = false;
+
+      const furigana = "けしゴム";
+      const kanji = "消しゴム";
+      const { kanjis, furiganas, nonKanjis, startsWKana } = furiganaParse(
+        furigana,
+        kanji
+      );
+
+      expect(kanjis).to.deep.eq(expectedKanjis);
+      expect(furiganas).to.deep.eq(expectedFuriganas);
+      expect(nonKanjis).to.deep.eq(expectedNonKanjis);
+      expect(startsWKana).to.deep.eq(expectedStartsWHiragana);
+    });
+
   });
 });
 

--- a/test/unit/helper/JapaneseText.js
+++ b/test/unit/helper/JapaneseText.js
@@ -38,7 +38,7 @@ describe("JapanseText", function () {
       expect(wrapper.text()).to.equal(expected);
     })
 
-    it("no furigana", function () {
+    it("furigana", function () {
       const furigana = "きたない"
       const kanji = "汚い";
 
@@ -94,7 +94,7 @@ describe("JapanseText", function () {
 
       expect(actual).to.throw(Error, "The two phrases do not match");
     });
-    it("failed parse validation shold throw", function () {
+    it("failed parse validation should throw", function () {
       const furigana = "いつつ"
       const kanji = "五つ";
 
@@ -103,6 +103,27 @@ describe("JapanseText", function () {
       expect(actual).to.throw(Error, "Failed to parse text to build furigana");
     });
 
+    it("failed parse validation w/ space workaround should not throw", function () {
+      const expectedKanjis = ["五"];
+      const expectedFuriganas = ["いつ"];
+      const expectedNonKanjis = ["つ"];
+      const expectedStartsWHiragana = false;
+
+      const furigana = "いつ つ"
+      const kanji = "五 つ";
+
+      const { kanjis, furiganas, nonKanjis, startsWHiragana } = furiganaParse(
+        furigana,
+        kanji
+      );
+
+      expect(kanjis, "kanjis").to.deep.eq(expectedKanjis);
+      expect(furiganas, "furiganas").to.deep.eq(expectedFuriganas);
+      expect(nonKanjis, "nonkanjis").to.deep.eq(expectedNonKanjis);
+      expect(startsWHiragana, "startsWHiragana").to.deep.eq(
+        expectedStartsWHiragana
+      );
+    });
 
     it("starting kanji ending hiragana", function () {
       const expectedKanjis = ["汚"];


### PR DESCRIPTION
- use space character to workaround parsing failure of words with repeating characters
- parse katakana the same way as hiragana characters (no furigana shown)